### PR TITLE
Set up container permissions for filestore

### DIFF
--- a/docker/master/Dockerfile
+++ b/docker/master/Dockerfile
@@ -51,6 +51,9 @@ COPY . .
 
 RUN ./build_protos.sh
 
+# For manual testing
+RUN apt-get -y update; apt-get -y install curl; apt-get -y install unzip
+
 # Switch to the non-privileged user to run the application.
 USER appuser
 

--- a/k8s-deployment/master-deployment.yaml
+++ b/k8s-deployment/master-deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: master-app
     spec:
+      initContainers:
+      - name: init-permissions
+        image: busybox
+        command: [ "sh", "-c", "chown -R 10001:10001 /mapreduce" ]
+        volumeMounts:
+          - mountPath: /mapreduce
+            name: fileserver
       containers:
       - name: master-container
         image: $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/irio-map-reduce-master:latest

--- a/k8s-deployment/worker-deployment.yaml
+++ b/k8s-deployment/worker-deployment.yaml
@@ -14,6 +14,13 @@ spec:
       labels:
         app: worker-app
     spec:
+      initContainers:
+      - name: init-permissions
+        image: busybox
+        command: [ "sh", "-c", "chown -R 10001:10001 /mapreduce" ]
+        volumeMounts:
+          - mountPath: /mapreduce
+            name: fileserver
       containers:
       - name: worker-container
         image: $REGION-docker.pkg.dev/$PROJECT_ID/$REPOSITORY_NAME/irio-map-reduce-worker:latest


### PR DESCRIPTION
Now the program has access to the mounted volume.

To test yourself (and I encourage the reviewer to try):
* run ./setup_all
* after pods are running, run `kubectl get pods` and get the master pod name
*  run `kubectl exec -it <master_pod_name> -- /bin/sh`. Now you are logged in as `appuser`. 
* Go into the mapreduce dir with `cd /mapreduce` and execute `curl https://students.mimuw.edu.pl/~aa429136/input.zip -o input.zip`
* unzip the files with `unzip input.zip`

Now if everything is correct, you can access any of the worker pods and check if the files are in fact there. 

For now getting all the input files is an overkill, as we could have just done `touch file`, but I am outlining this here so that the person who works on actually running the compute has a way to test it manually before implementing file upload logic.