### PR TITLE
Fix bug with num_partitions

### DIFF
--- a/src/worker/example_mapper.py
+++ b/src/worker/example_mapper.py
@@ -38,6 +38,11 @@ def main():
             for word in line.strip().split():
                 counter[word] += 1
 
+    # if some partition ends up empty, we still want the file to exist
+    for partition_num in range(num_partitions):
+        with output_dir.joinpath(str(partition_num)).open("a"):
+            pass
+
     for word, count in counter.items():
         partition_num = _get_partition_idx(word, num_partitions)
         with output_dir.joinpath(str(partition_num)).open("a") as output_file:

--- a/tests/test_mapreduce.py
+++ b/tests/test_mapreduce.py
@@ -3,7 +3,11 @@ from typing import List
 
 import pytest
 
-from src.generated_files.master_pb2 import RegisterServiceMes, MapReduceRequest
+from src.generated_files.master_pb2 import (
+    RegisterServiceMes,
+    MapReduceRequest,
+    MapReduceResponse,
+)
 from src.generated_files.master_pb2_grpc import MasterStub
 from src.worker.server import build_worker_server
 from tests.utils import read_mapreduce_outputs, count_words
@@ -27,24 +31,62 @@ def worker_ports():
         server.stop(grace=None)
 
 
-@pytest.mark.parametrize("num_partitions", [1, 2, 4, 8])
-def test_big_files_multiple_workers(
-    worker_ports: List[int], master_client: MasterStub, num_partitions: int
-):
+def _register_workers_and_send_request(
+    worker_ports: List[int], client: MasterStub, num_partitions: int, input_dir: Path
+) -> MapReduceResponse:
     for worker_port in worker_ports:
-        master_client.RegisterService(
+        client.RegisterService(
             RegisterServiceMes(service_address="localhost", service_port=worker_port)
         )
 
-    response = master_client.MapReduce(
+    return client.MapReduce(
         MapReduceRequest(
-            input_dir=TEST_INPUT_DIR.absolute().as_posix(),
+            input_dir=input_dir.absolute().as_posix(),
             num_partitions=num_partitions,
             mapper_path=MAPPER_PATH.as_posix(),
             reducer_path=REDUCER_PATH.as_posix(),
         ),
     )
 
+
+@pytest.mark.parametrize("num_partitions", [1, 2, 4, 8])
+def test_big_files_multiple_workers(
+    worker_ports: List[int], master_client: MasterStub, num_partitions: int
+):
+    response = _register_workers_and_send_request(
+        worker_ports, master_client, num_partitions, TEST_INPUT_DIR
+    )
+
     assert read_mapreduce_outputs(Path(response.output_dir)) == count_words(
         TEST_INPUT_DIR
     )
+
+
+def test_when_given_file_with_more_partitions_then_actual_buckets_then_doesnt_freeze(
+    worker_ports: List[int], master_client: MasterStub, tmp_path: Path
+):
+    with open(tmp_path / "input.txt", "w") as f:
+        f.write("asdf bcda")
+
+    response = _register_workers_and_send_request(
+        worker_ports, master_client, 10, tmp_path
+    )
+
+    assert read_mapreduce_outputs(Path(response.output_dir)) == count_words(tmp_path)
+
+
+def test_when_given_files_with_more_partitions_then_actual_buckets_then_doesnt_freeze(
+    worker_ports: List[int], master_client: MasterStub, tmp_path: Path
+):
+    with open(tmp_path / "input_1.txt", "w") as f:
+        f.write("asdf bcda")
+    with open(tmp_path / "input_2.txt", "w") as f:
+        f.write("asdf")
+    with open(tmp_path / "input_2.txt", "w") as f:
+        f.write("bcda")
+
+    response = _register_workers_and_send_request(
+        worker_ports, master_client, 10, tmp_path
+    )
+
+    assert read_mapreduce_outputs(Path(response.output_dir)) == count_words(tmp_path)


### PR DESCRIPTION
When the passed num_partitions was too large
the mapper did not create the files for some partitions, but was passing those paths to the reducer. Reducer then tried to open those non-existing files, which raised an error.

Many solutions were possible, for example:
- make reducer check if the file exists before opening
- send only paths for created files
- create "blank" files for partitions that ended up not being used

I went with creating those blank files, since it just seems that providing these files is the mappers responsibility and it seemed easier.

I added tests for this -- without the mapper patch, these tests freeze.